### PR TITLE
Remove unused shader "begild.fs"

### DIFF
--- a/mod_info.lua
+++ b/mod_info.lua
@@ -226,7 +226,6 @@ SMODS.Shader({ key = 'akashic', path = 'akashic.fs' })
 SMODS.Shader({ key = 'ghostRare', path = 'ghostRare.fs' })
 SMODS.Shader({ key = 'secretRare', path = 'secretRare.fs' })
 SMODS.Shader({ key = 'shadowChrome', path = 'shadowChrome.fs' })
-SMODS.Shader({ key = 'begild', path = 'begild.fs' })
 
 sendInfoMessage("Loading all subfiles", "FoxMods-config.lua")
 


### PR DESCRIPTION
Removes "begild.fs" from shaders, as it it's not used, and causes a crash on start.